### PR TITLE
ci: init continuous verifier

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Formal verification
+run-name: Verify Wadray
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Get the only thing that usually is reliable in CI
+        uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:nixos-23.11
+      - name: Update dependencies
+        run: nix-shell -p elan --run "lake update"
+      - name: Download mathlib4 cache
+        run: nix-shell -p elan --run "lake exe cache get"
+      - name: Verify the library
+        run: nix-shell -p elan --run "lake build"


### PR DESCRIPTION
This ensures that anyone can reproduce the results and can get rid of the submodule issue.